### PR TITLE
Add module to types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,21 @@
-type TSanitizer = (s: string) => string;
+declare module 'string-sanitizer' {
+  type TSanitizer = (s: string) => string;
 
-interface ISanitize extends TSanitizer {
-  keepUnicode: TSanitizer;
-  keepSpace: TSanitizer;
-  addFullstop: TSanitizer;
-  addUnderscore: TSanitizer;
-  addDash: TSanitizer;
-  removeNumber: TSanitizer;
-  keepNumber: TSanitizer;
+  interface ISanitize extends TSanitizer {
+    keepUnicode: TSanitizer;
+    keepSpace: TSanitizer;
+    addFullstop: TSanitizer;
+    addUnderscore: TSanitizer;
+    addDash: TSanitizer;
+    removeNumber: TSanitizer;
+    keepNumber: TSanitizer;
+  }
+
+  const sanitize: ISanitize;
+  const addFullstop: TSanitizer;
+  const addUnderscore: TSanitizer;
+  const addDash: TSanitizer;
+  const removeSpace: TSanitizer;
+
+  export { sanitize, addFullstop, addUnderscore, addDash, removeSpace };
 }
-
-const sanitize: ISanitize;
-const addFullstop: TSanitizer;
-const addUnderscore: TSanitizer;
-const addDash: TSanitizer;
-const removeSpace: TSanitizer;
-
-export { sanitize, addFullstop, addUnderscore, addDash, removeSpace };


### PR DESCRIPTION
Fixed #8 

Resolves the error when building:

```
yarn run v1.22.11
$ tsc
node_modules/string-sanitizer/index.d.ts:13:1 - error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.

13 const sanitize: ISanitize;
   ~~~~~


Found 1 error.

error Command failed with exit code 2.
```