### PR TITLE
fix: email validation infinite loop bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ exports.validate = function (str) {
 
 //Username & Email
 exports.validate.isEmail = function (str) {
-  const regex = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/;
+  const regex = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(?:\.\w{2,})+$/;
   if (regex.test(str)) {
     return str;
   } else {


### PR DESCRIPTION
This commit prevents the infinite loop that can be triggered when attempting to validate an email address with a very long TLD.
Long TLDs still take some time to process, but not infinite time. I don't believe this regex is perfect but it is an improvement.